### PR TITLE
Display parser and lexer errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1440,9 +1440,9 @@
       "optional": true
     },
     "ecca": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/ecca/-/ecca-0.4.6.tgz",
-      "integrity": "sha1-akjW4OQk60eluGtAszPKEvoRm+s="
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/ecca/-/ecca-0.4.8.tgz",
+      "integrity": "sha1-IhgTmVnKtlSPpN5Cz1fcNZJUm2c="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "^4.0.0",
     "bootstrap": "^4.0.0-alpha.6",
     "core-js": "^2.4.1",
-    "ecca": "^0.4.6",
+    "ecca": "^0.4.8",
     "font-awesome": "^4.7.0",
     "ngx-clipboard": "^3.0.7",
     "rxjs": "^5.1.0",

--- a/src/app/equations/equations.component.html
+++ b/src/app/equations/equations.component.html
@@ -1,3 +1,15 @@
+<div *ngIf="expression?.LexerErrors?.length > 0" class="alert alert-danger w-75 mx-auto" role="alert">
+  <h4 class="alert-heading">Lexer Errors</h4>
+  <ul class="mb-0">
+    <li *ngFor="let lexerError of expression.LexerErrors">{{ lexerError.message }}</li>
+  </ul>
+</div>
+<div *ngIf="expression?.ParserErrors?.length > 0" class="alert alert-danger w-75 mx-auto" role="alert">
+  <h4 class="alert-heading">Parser Errors</h4>
+  <ul class="mb-0">
+    <li *ngFor="let parserError of expression.ParserErrors">{{ parserError.message }}</li>
+  </ul>
+</div>
 <div class="card w-75 mx-auto mb-3">
   <div class="card-block">
     <div class="input-group input-group-lg">

--- a/src/app/equations/equations.component.ts
+++ b/src/app/equations/equations.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, Inject, Renderer, OnInit } from '@angular/core';
 import { MathJaxDirective } from '../mathjax.directive';
-import { Expression, generateRawTeX, generateDecoratedTeX } from 'ecca';
+import { Expression, Variable, generateRawTeX, generateDecoratedTeX } from 'ecca';
 
 @Component({
   selector: 'app-equations',
@@ -41,7 +41,7 @@ export class EquationsComponent implements OnInit {
     }
   }
 
-  setVariableHighlights(variable: any, showHighlight: boolean) {
+  setVariableHighlights(variable: Variable, showHighlight: boolean) {
     if (variable.instances.length > 0) {
       // Repeat for each instance of the the specified variable
       for (let identifierElement of variable.instances) {

--- a/src/app/equations/equations.component.ts
+++ b/src/app/equations/equations.component.ts
@@ -26,12 +26,23 @@ export class EquationsComponent implements OnInit {
 
   updateEquation() {
     if (/\S/.test(this.inputString)) {
-      // String is not empty and not just whitespace, generate an Expression from it
-      this.expression = new Expression(this.inputString);
+      // String is not empty and not just whitespace, nullify the existing
+      // variable in case the Expression constructor fails (and clear the TeX
+      // strings)
+      this.expression = null;
+      this.rawTeX = '';
+      this.decoratedTeX = '';
 
-      // Generate the raw and decorated TeX from the Expression
-      this.rawTeX = generateRawTeX(this.expression);
-      this.decoratedTeX = generateDecoratedTeX(this.expression);
+      // Attempt to generate an Expression object from the string
+      try {
+        this.expression = new Expression(this.inputString);
+      } catch (e) {}
+
+      if (this.expression != null) {
+        // Generate the raw and decorated TeX from the Expression
+        this.rawTeX = generateRawTeX(this.expression);
+        this.decoratedTeX = generateDecoratedTeX(this.expression);
+      }
     } else {
       // String cannot be used to generate an Expression, clear related member variables
       this.inputString = '';


### PR DESCRIPTION
Add the functionality to display parser and lexer errors back in. It was removed when switching to ecca.