### PR TITLE
Load MathJax from CDNJS, fixes #25

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,19 +4,20 @@
   <meta charset="utf-8">
   <title>Equation Cloud</title>
   <base href="/">
-
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
-      jax: ["input/TeX", "output/HTML-CSS"],
-      "HTML-CSS": { scale: 130 },
+      jax: ["input/TeX", "output/CommonHTML"],
+      CommonHTML: {
+        scale: 130
+      },
       messageStyle: "none",
       showMathMenu: false,
       showMathMenuMSIE: false
     });
   </script>
-  <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
+  <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"></script>
 </head>
 <body>
   <app-root>Loading...</app-root>


### PR DESCRIPTION
In addition to loading from recommended 3rd party CDN, make changes to
configuration as recommended in MathJax docs:
- Load specific version of MathJax, not just latest available.
- Use CommonHTML output processor.